### PR TITLE
Sanitize xml attributes.

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -47,7 +46,7 @@ function Jenkins(runner) {
 
   function genSuiteReport() {
     writeString('<testsuite')
-    writeString(' name="'+currentSuite.suite.fullTitle()+'"');
+    writeString(' name="'+htmlEscape(currentSuite.suite.fullTitle())+'"');
     writeString(' tests="'+currentSuite.tests.length+'"');
     writeString(' failures="'+currentSuite.failures+'"');
     writeString(' skipped="'+(currentSuite.tests.length-currentSuite.failures-currentSuite.passes)+'"');
@@ -57,8 +56,8 @@ function Jenkins(runner) {
 
     currentSuite.tests.forEach(function(test) {
       writeString('<testcase');
-      writeString(' classname="'+currentSuite.suite.fullTitle()+'"');
-      writeString(' name="'+test.title+'"')
+      writeString(' classname="'+htmlEscape(currentSuite.suite.fullTitle())+'"');
+      writeString(' name="'+htmlEscape(test.title)+'"')
       writeString(' time="'+(test.duration/1000)+'"');
       if (test.state == "failed") {
         writeString('>\n');


### PR DESCRIPTION
Hi! 

Thanks for such a great project.
I found a little bug: If my test name contains quote mark (") then the reporter is generating invalid XML. I belive that making usage of yours htmlEscape helper will solve that problem.

Sanitize testsuite#name, testcase#calssname and testcase#name attributes, to allow using quote marks in test names.
