### PR TITLE
Changed the initiation of af suite to listen for the "suite" event

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -151,14 +151,13 @@ function Jenkins(runner) {
     self.epilogue.call(self);
   });
 
-  var lastSuiteTitle;
-  runner.on('test', function(test) {
-    if (test.parent.fullTitle() != lastSuiteTitle) {
+  runner.on('suite', function (suite) {
+    if (currentSuite) {
       endSuite();
-      lastSuiteTitle = test.parent.fullTitle();
-      startSuite(test.parent);
     }
+    startSuite(suite);
   });
+
 
   runner.on('test end', function(test) {
     addTestToSuite(test);


### PR DESCRIPTION
The current implementation was causing the reporter to crash with the following error :

```
var n = ++currentSuite.failures;
[11:16:57][Step 3/3]                           ^
[11:16:57][Step 3/3] TypeError: Cannot read property 'failures' of undefined
```

This is as far as i can see because the test event is not always called before a fail event.
I have moved the startSuite call to the "suite" event, which has fixed the error. 
