### PR TITLE
Add stack trace on failure in before hook

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -73,36 +73,34 @@ function Jenkins(runner, options) {
     writeString(' time="'+(currentSuite.duration/1000)+'"');
     writeString('>\n');
 
-    if (currentSuite.tests.length === 0 && currentSuite.failures > 0) {
-      writeString('<testcase');
-      writeString(' classname="'+htmlEscape(currentSuite.suite.fullTitle())+'"');
-      writeString(' name="'+htmlEscape(currentSuite.suite.fullTitle())+' before"');
-      writeString('>\n');
-      writeString('<failure message="Failed during before hook"/>');
-      writeString('</testcase>\n');
-    } else {
-      currentSuite.tests.forEach(function(test) {
-        writeString('<testcase');
-        writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
-        writeString(' name="'+htmlEscape(test.title)+'"');
-        writeString(' time="'+(test.duration/1000)+'"');
-        if (test.state == "failed") {
-          writeString('>\n');
-          writeString('<failure message="');
-          if (test.err.message) writeString(htmlEscape(test.err.message));
-          writeString('">\n');
-          writeString(htmlEscape(unifiedDiff(test.err)));
-          writeString('\n</failure>\n');
-          writeString('</testcase>\n');
-        } else if(test.state === undefined) {
-          writeString('>\n');
-          writeString('<skipped/>\n');
-          writeString('</testcase>\n');
-        } else {
-          writeString('/>\n');
-        }
-      });
+    var tests = currentSuite.tests;
+
+    if (tests.length === 0 && currentSuite.failures > 0) {
+      // Get the runnable that failed, which is a beforeAll or beforeEach
+      tests = [currentSuite.suite.ctx.runnable()];
     }
+
+    tests.forEach(function(test) {
+      writeString('<testcase');
+      writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
+      writeString(' name="'+htmlEscape(test.title)+'"');
+      writeString(' time="'+(test.duration/1000)+'"');
+      if (test.state == "failed") {
+        writeString('>\n');
+        writeString('<failure message="');
+        if (test.err.message) writeString(htmlEscape(test.err.message));
+        writeString('">\n');
+        writeString(htmlEscape(unifiedDiff(test.err)));
+        writeString('\n</failure>\n');
+        writeString('</testcase>\n');
+      } else if(test.state === undefined) {
+        writeString('>\n');
+        writeString('<skipped/>\n');
+        writeString('</testcase>\n');
+      } else {
+        writeString('/>\n');
+      }
+    });
 
     writeString('</testsuite>\n');
   }


### PR DESCRIPTION
Get the runnable that failed, which is a beforeAll or beforeEach and treat it as a "normal" test failure.