### PR TITLE
enable test paths to represent packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The environment variable `JUNIT_REPORT_NAME` is used for giving an optional name
 
 The environment variable `JUNIT_REPORT_STACK` is used to enable writing the stack trace for failed tests.
 
+The environment variable `JUNIT_REPORT_PACKAGES` is used to enable package name to be represented by relative path to test.
+
 Example console output of the reporter:
 
 ```

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -43,6 +43,7 @@ function Jenkins(runner, options) {
   options.junit_report_stack = process.env.JUNIT_REPORT_STACK || options.junit_report_stack;
   options.junit_report_path = process.env.JUNIT_REPORT_PATH || options.junit_report_path;
   options.junit_report_name = process.env.JUNIT_REPORT_NAME || options.junit_report_name || 'Mocha Tests';
+  options.junit_report_packages = process.env.JUNIT_REPORT_PACKAGES || options.junit_report_packages;
   options.jenkins_reporter_enable_sonar = process.env.JENKINS_REPORTER_ENABLE_SONAR || options.jenkins_reporter_enable_sonar;
   options.jenkins_reporter_test_dir =  process.env.JENKINS_REPORTER_TEST_DIR || options.jenkins_reporter_test_dir  || 'test';
 
@@ -83,7 +84,7 @@ function Jenkins(runner, options) {
     } else {
       currentSuite.tests.forEach(function(test) {
         writeString('<testcase');
-        writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
+        writeString(' classname="'+htmlEscape(getClassName(test, currentSuite.suite))+'"');
         writeString(' name="'+htmlEscape(test.title)+'"');
         writeString(' time="'+(test.duration/1000)+'"');
         if (test.state == "failed") {
@@ -192,17 +193,25 @@ function Jenkins(runner, options) {
     return msg;
   }
 
+  function getRelativePath(test) {
+    var relativeTestDir = options.jenkins_reporter_test_dir,
+        absoluteTestDir = path.join(process.cwd(), relativeTestDir);
+    return path.relative(absoluteTestDir, test.file);
+  }
+
   function getClassName(test, suite) {
-    var title = suite.fullTitle();
     if (options.jenkins_reporter_enable_sonar) {
       // Inspired by https://github.com/pghalliday/mocha-sonar-reporter
-      var relativeTestDir = options.jenkins_reporter_test_dir,
-          absoluteTestDir = path.join(process.cwd(), relativeTestDir),
-          relativeFilePath = path.relative(absoluteTestDir, test.file),
+      var relativeFilePath = getRelativePath(test),
           fileExt = path.extname(relativeFilePath);
-      title = relativeFilePath.replace(new RegExp(fileExt+"$"), '');
+      return relativeFilePath.replace(new RegExp(fileExt+"$"), '');
     }
-    return htmlEscape(title);
+    if (options.junit_report_packages) {
+      var testPackage = getRelativePath(test).replace(/[^\/]*$/, ''),
+          delimiter = testPackage ? '.' : '';
+      return testPackage + delimiter + suite.fullTitle();
+    }
+    return suite.fullTitle();
   }
 
   runner.on('start', function() {


### PR DESCRIPTION
It would be great if relative path to test could represent test's package. It is more or less analogy to Java's package system. Please, consider this feature.