### PR TITLE
added screenshot option and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ After this you should be able to add `Publish JUnit test result report` in your 
 
 After all this setting up, just click `Save` and start building, you should get all errors nicely both to the console log as the tests are being run and finally to the Jenkins reports.
 
+
+Enabling Jenkins Screenshots
+----------------------------
+
+Jenkins screenshot attachments can be written to the report to allow for a screenshot attachment in each test failure. Simply specify a reporterOption of `spec` or `loop`. This writes a `system-out` xml element to the JUnit report, leveraging the `Publish test attachments` feature of the `JUnit Attachments Plugin`.
+
+`spec` will write the full path of the screenshot with a filename consisting of "classname+test.title+extension". `loop` pulls and sorts all screenshots of a particular extension from `JUNIT_REPORT_PATH` and writes them in order according to the names of the files pulled.
+
+Screenshot extension defaults to ".png", but can also be passed in with the `imagetype` reporterOption.
+
+
 SonarQube Integration
 ---------------------
 

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -81,6 +81,23 @@ function Jenkins(runner, options) {
       writeString('<failure message="Failed during before hook"/>');
       writeString('</testcase>\n');
     } else {
+
+      //grabbing screenshots for 'loop' based approach
+      if (options.screenshots) {
+        var imageType = options.imagetype || 'png';
+        if (options.screenshots == 'loop') {
+          var screenshotIndex = 0;
+          var screenshots = [];
+          var screenshot = '';
+          var files = fs.readdirSync(options.junit_report_path).sort();
+          for(var i in files) {
+            if(path.extname(files[i]) === "." + imageType){
+              screenshots.push(files[i]);
+            }
+          }
+        }
+      }
+
       currentSuite.tests.forEach(function(test) {
         writeString('<testcase');
         writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
@@ -93,6 +110,23 @@ function Jenkins(runner, options) {
           writeString('">\n');
           writeString(htmlEscape(unifiedDiff(test.err)));
           writeString('\n</failure>\n');
+
+          //screenshot name is either pulled in sorted order from junit_report_path
+          //or set as classname + title, then written with Jenkins ATTACHMENT tag
+          if (options.screenshots) {
+            var screenshotDir = path.join(process.cwd(), options.junit_report_path);
+            if (options.screenshots == 'loop') {
+              screenshot = path.join(screenshotDir, screenshots[screenshotIndex]);
+              screenshotIndex++;
+            } else {
+              screenshot = path.join(screenshotDir,
+                  getClassName(test, currentSuite.suite) + test.title + "." + imageType);
+            }
+            writeString('<system-out>\n');
+            writeString('[[ATTACHMENT|' + screenshot + ']]');
+            writeString('\n</system-out>\n');
+          }
+
           writeString('</testcase>\n');
         } else if(test.state === undefined) {
           writeString('>\n');


### PR DESCRIPTION
Jenkins screenshot attachments can be written to to the report to allow for a screenshot attachment in each failure.  Simply specify a reporterOption of `spec` or `loop`.  This writes a `system-out` xml element to the Junit report, leveraging the `Publish test attachments` feature of the `JUnit Attachments Plugin`.

`spec` will write the full path of the screenshot, with a filename consisting of "classname+test.title+extension".

`loop` pulls and sorts all screenshots of a particular extension from `JUNIT_REPORT_PATH` and writes them in order according to the names of of the files pulled.

Screenshot extension defaults to ".png", but can also be passed with the `imagetype` reporterOption.