### PR TITLE
Include console output in junit report.

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -8,7 +8,8 @@ var Base = require('mocha').reporters.Base
   , fs = require('fs')
   , path = require('path')
   , diff= require('diff')
-  , mkdirp = require('mkdirp');
+  , mkdirp = require('mkdirp')
+  , util = require('util');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -19,6 +20,11 @@ var Date = global.Date
   , setInterval = global.setInterval
   , clearTimeout = global.clearTimeout
   , clearInterval = global.clearInterval;
+
+/**
+ * Save original console.log.
+ */
+var log = console.log.bind(console);
 
 /**
  * Expose `Jenkins`.
@@ -85,22 +91,26 @@ function Jenkins(runner, options) {
         writeString('<testcase');
         writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
         writeString(' name="'+htmlEscape(test.title)+'"');
-        writeString(' time="'+(test.duration/1000)+'"');
+        writeString(' time="'+(test.duration/1000)+'">\n');
         if (test.state == "failed") {
-          writeString('>\n');
           writeString('<failure message="');
           if (test.err.message) writeString(htmlEscape(test.err.message));
           writeString('">\n');
           writeString(htmlEscape(unifiedDiff(test.err)));
           writeString('\n</failure>\n');
-          writeString('</testcase>\n');
         } else if(test.state === undefined) {
-          writeString('>\n');
           writeString('<skipped/>\n');
-          writeString('</testcase>\n');
-        } else {
-          writeString('/>\n');
         }
+
+        if (test.logEntries && test.logEntries.length) {
+          writeString('<system-out><![CDATA[');
+          test.logEntries.forEach(function (entry) {
+            writeString(util.format.apply(util, entry) + '\n');
+          });
+          writeString(']]></system-out>\n');
+        }
+
+        writeString('</testcase>\n');
       });
     }
 
@@ -115,18 +125,18 @@ function Jenkins(runner, options) {
       failures: 0,
       passes: 0
     };
-    console.log();
-    console.log("  "+suite.fullTitle());
+    log();
+    log("  "+suite.fullTitle());
   }
 
   function endSuite() {
     if (currentSuite != null) {
       currentSuite.duration = new Date - currentSuite.start;
-      console.log();
-      console.log('  Suite duration: '+(currentSuite.duration/1000)+' s, Tests: '+currentSuite.tests.length);
+      log();
+      log('  Suite duration: '+(currentSuite.duration/1000)+' s, Tests: '+currentSuite.tests.length);
       try {
       genSuiteReport();
-      } catch (err) { console.log(err) }
+      } catch (err) { log(err) }
       currentSuite = null;
     }
   }
@@ -234,16 +244,23 @@ function Jenkins(runner, options) {
     startSuite(suite);
   });
 
+  runner.on('test', function (test) {
+    test.logEntries = [];
+    console.log = function () {
+      test.logEntries.push(Array.prototype.slice.call(arguments));
+    };
+  });
 
   runner.on('test end', function(test) {
     addTestToSuite(test);
+    console.log = log;
   });
 
   runner.on('pending', function(test) {
     var fmt = indent()
       + color('checkmark', '  -')
       + color('pending', ' %s');
-    console.log(fmt, test.title);
+    log(fmt, test.title);
   });
 
   runner.on('pass', function(test) {
@@ -252,14 +269,14 @@ function Jenkins(runner, options) {
       + color('checkmark', '  '+Base.symbols.dot)
       + color('pass', ' %s: ')
       + color(test.speed, '%dms');
-   console.log(fmt, test.title, test.duration);
+   log(fmt, test.title, test.duration);
   });
 
   runner.on('fail', function(test, err) {
     var n = ++currentSuite.failures;
     var fmt = indent()
       + color('fail', '  %d) %s');
-    console.log(fmt, n, test.title);
+    log(fmt, n, test.title);
   });
 }
 


### PR DESCRIPTION
I'm working on a project where we're using this reporter to create a junit report that serves as documentation for a REST API we're creating. We log extra information, such as requests/responses, which is valuable for the third party clients of the API, so we need to include the console output in the junit report.

This PR captures console.log for each test, and includes the entries in the report. 

As a side effect, log output is muted for the console reporter. This is something we like (clean console report, detailed junit report), but if you disagree, I can update the PR and make it optional (via a parameter).