### PR TITLE
add screenshot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ After this you should be able to add `Publish JUnit test result report` in your 
 
 After all this setting up, just click `Save` and start building, you should get all errors nicely both to the console log as the tests are being run and finally to the Jenkins reports.
 
+
+Enabling Jenkins Screenshots
+----------------------------
+
+Jenkins screenshot attachments can be written to the report to allow for a screenshot attachment in each test failure. Simply specify a reporterOption of `spec` or `loop`. This writes a `system-out` xml element to the JUnit report, leveraging the `Publish test attachments` feature of the `JUnit Attachments Plugin`.
+
+`spec` will write the full path of the screenshot with a filename consisting of "classname+test.title+extension". `loop` pulls and sorts all screenshots of a particular extension from `JUNIT_REPORT_PATH` and writes them in order according to the names of the files pulled.
+
+Screenshot extension defaults to ".png", but can also be passed in with the `imagetype` reporterOption.
+
+
 SonarQube Integration
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ Jenkins screenshot attachments can be written to the report to allow for a scree
 
 Screenshot extension defaults to ".png", but can also be passed in with the `imagetype` reporterOption.
 
+Here is an example of generating a screenshot in Mocha for using the `spec` option. Note that whatever is in the `describe` statement is what mocha-jenkins-reporter sees with `currentSuite.suite.fullTitle()`. Let us call that `suitename`. Let's call `classname` what the reporter sees with `getClassName(test, currentSuite.suite)`.  Finally, let's call `title` what you can extract on the Mocha side with `this.currentTest.title`. In this example I'm assuming that JUNIT_REPORT_PATH ends with '/'.
+```
+var screenshot = process.env.JUNIT_REPORT_PATH + suitename + classname + title + '.png';
+client.saveScreenshot(screenshot);
+```
+Here is the Mocha call for running a test that leverages this option:
+```
+mocha screenshot_test.js --reporter mocha-jenkins-reporter --reporter-options screenshots=spec
+```
+The `loop` option can be used in situations where you may have multiple XML reports and would perhaps prefer to timestamp screenshots then write them in order to the XML report. Here is an example of generating a screenshot using `loop`:
+```
+var d = new Date(),
+    n = d.getTime().toString(),
+    customScreenshotText = "mycustomscreenshots",
+    screenshot = process.env.JUNIT_REPORT_PATH + n + "_" + customScreenshotText + ".png";
+client.saveScreenshot(screenshot);
+```
+Here is the Mocha call that allows you to loop through the screenshots and write to the report all that contain `customScreenshotText`:
+```
+mocha screenshot_test.js --reporter mocha-jenkins-reporter --reporter-options screenshots=loop,imagestring=mycustomscreenshots
+```
+
 SonarQube Integration
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ General Information
 
 First you need to add the library to your package.json, you can use the following setting to get the latest version:
 
-`"mocha-jenkins-reporter": "0.1.9"`
+`"mocha-jenkins-reporter": "0.2.0"`
 
 For the actual test run you can use the following Makefile:
 
@@ -29,6 +29,8 @@ The environment variable `JUNIT_REPORT_PATH` is used for passing the output file
 The environment variable `JUNIT_REPORT_NAME` is used for giving an optional name for testsuites, defaults to "Mocha Tests".
 
 The environment variable `JUNIT_REPORT_STACK` is used to enable writing the stack trace for failed tests.
+
+The environment variable `JUNIT_REPORT_PACKAGES` is used to enable package name to be represented by relative path to test.
 
 Example console output of the reporter:
 
@@ -70,16 +72,14 @@ After this you should be able to add `Publish JUnit test result report` in your 
 
 After all this setting up, just click `Save` and start building, you should get all errors nicely both to the console log as the tests are being run and finally to the Jenkins reports.
 
-
 Enabling Jenkins Screenshots
 ----------------------------
 
 Jenkins screenshot attachments can be written to the report to allow for a screenshot attachment in each test failure. Simply specify a reporterOption of `spec` or `loop`. This writes a `system-out` xml element to the JUnit report, leveraging the `Publish test attachments` feature of the `JUnit Attachments Plugin`.
 
-`spec` will write the full path of the screenshot with a filename consisting of "classname+test.title+extension". `loop` pulls and sorts all screenshots of a particular extension from `JUNIT_REPORT_PATH` and writes them in order according to the names of the files pulled.
+`spec` will write the full path of the screenshot with a filename consisting of "suitename+classname+test.title+extension". `loop` pulls and sorts all screenshots with specific filename text from `JUNIT_REPORT_PATH` and writes them in order according to the names of the files pulled. The `imagestring` reporterOption can be used to specify what files to pull, allowing for custom screenshot naming conventions on the mocha side, otherwise it defaults to the test suite name.
 
 Screenshot extension defaults to ".png", but can also be passed in with the `imagetype` reporterOption.
-
 
 SonarQube Integration
 ---------------------
@@ -92,7 +92,7 @@ License
 -------
 
 ```
-Copyright (c) 2015 Juho Vähä-Herttua and contributors
+Copyright (c) 2015-2016 Juho Vähä-Herttua and contributors
 Copyright (c) 2013-2014 Futurice Ltd and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -53,6 +53,15 @@ function Jenkins(runner, options) {
   options.jenkins_reporter_enable_sonar = process.env.JENKINS_REPORTER_ENABLE_SONAR || options.jenkins_reporter_enable_sonar;
   options.jenkins_reporter_test_dir =  process.env.JENKINS_REPORTER_TEST_DIR || options.jenkins_reporter_test_dir  || 'test';
 
+  // From http://stackoverflow.com/a/961504 modified for JavaScript
+  function removeInvalidXmlChars(str) {
+    // Remove invalid surrogate low bytes first, no lookbehind in JS :(
+    // Should be equal to str.replace(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '')
+    str = str.replace(/([^\ud800-\udbff])[\udc00-\udfff]|^[\udc00-\udfff]/g, '$1');
+    // Remove other characters that are not valid for XML documents
+    return str.replace(/[\ud800-\udbff](?![\udc00-\udfff])|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\ufeff\ufffe\uffff]/g, '');
+  }
+
   function writeString(str) {
     if (fd) {
       var buf = new Buffer(str);
@@ -109,7 +118,6 @@ function Jenkins(runner, options) {
       writeString(' name="'+htmlEscape(test.title)+'"');
       writeString(' time="'+(test.duration/1000)+'">\n');
       if (test.state == "failed") {
-
         writeString('<failure message="');
         if (test.err.message) writeString(htmlEscape(test.err.message));
         writeString('">\n');
@@ -128,10 +136,9 @@ function Jenkins(runner, options) {
                 getClassName(test, currentSuite.suite) + test.title + "." + imagetype);
           }
           writeString('<system-out>\n');
-          writeString('[[ATTACHMENT|' + screenshot + ']]');
-          writeString('\n</system-out>\n');
+          writeString('[[ATTACHMENT|' + screenshot + ']]\n');
+          writeString('</system-out>\n');
         }
-
       } else if(test.state === undefined) {
         writeString('<skipped/>\n');
       }
@@ -139,6 +146,7 @@ function Jenkins(runner, options) {
       if (test.logEntries && test.logEntries.length) {
         writeString('<system-out><![CDATA[');
         test.logEntries.forEach(function (entry) {
+          entry = removeInvalidXmlChars(entry);
           writeString(util.format.apply(util, entry) + '\n');
         });
         writeString(']]></system-out>\n');

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -81,6 +81,23 @@ function Jenkins(runner, options) {
       writeString('<failure message="Failed during before hook"/>');
       writeString('</testcase>\n');
     } else {
+
+      //grabbing screenshots for 'loop' based approach
+      if (options.screenshots) {
+        var imageType = options.imagetype || 'png';
+        if (options.screenshots == 'loop') {
+          var screenshotIndex = 0;
+          var screenshots = [];
+          var screenshot = '';
+          var files = fs.readdirSync(options.junit_report_path).sort();
+          for(var i in files) {
+            if(path.extname(files[i]) === "." + imageType){
+              screenshots.push(files[i]);
+            }
+          }
+        }
+      }
+
       currentSuite.tests.forEach(function(test) {
         writeString('<testcase');
         writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
@@ -93,6 +110,23 @@ function Jenkins(runner, options) {
           writeString('">\n');
           writeString(htmlEscape(unifiedDiff(test.err)));
           writeString('\n</failure>\n');
+
+          //screenshot name is either pulled in sorted order from junit_report_path
+          //or set as classname + title, then written with Jenkins ATTACHMENT tag
+          if (options.screenshots) {
+            var screenshotDir = path.join(process.cwd(), options.junit_report_path);
+            if (options.screenshots == 'loop') {
+              screenshot = path.join(screenshotDir, screenshots[screenshotIndex]);
+              screenshotIndex++;
+            } else {
+              screenshot = path.join(screenshotDir,
+                  getClassName(test, currentSuite.suite) + test.title + "." + imageType);
+            }
+            writeString('<system-out>\n');
+            writeString('[[ATTACHMENT|' + screenshot + ']]');
+            writeString('\n</system-out>\n');
+          }
+
           writeString('</testcase>\n');
         } else if(test.state === undefined) {
           writeString('>\n');

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -3,23 +3,23 @@
  */
 
 var Base = require('mocha').reporters.Base
-  , cursor = Base.cursor
-  , color = Base.color
-  , fs = require('fs')
-  , path = require('path')
-  , diff= require('diff')
-  , mkdirp = require('mkdirp')
-  , util = require('util');
+    , cursor = Base.cursor
+    , color = Base.color
+    , fs = require('fs')
+    , path = require('path')
+    , diff= require('diff')
+    , mkdirp = require('mkdirp')
+    , util = require('util');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
  */
 
 var Date = global.Date
-  , setTimeout = global.setTimeout
-  , setInterval = global.setInterval
-  , clearTimeout = global.clearTimeout
-  , clearInterval = global.clearInterval;
+    , setTimeout = global.setTimeout
+    , setInterval = global.setInterval
+    , clearTimeout = global.clearTimeout
+    , clearInterval = global.clearInterval;
 
 /**
  * Save original console.log.
@@ -139,6 +139,7 @@ function Jenkins(runner, options) {
           writeString('[[ATTACHMENT|' + screenshot + ']]\n');
           writeString('</system-out>\n');
         }
+
       } else if(test.state === undefined) {
         writeString('<skipped/>\n');
       }
@@ -146,8 +147,9 @@ function Jenkins(runner, options) {
       if (test.logEntries && test.logEntries.length) {
         writeString('<system-out><![CDATA[');
         test.logEntries.forEach(function (entry) {
-          entry = removeInvalidXmlChars(entry);
-          writeString(util.format.apply(util, entry) + '\n');
+          var outstr = util.format.apply(util, entry) + '\n';
+          outstr = removeInvalidXmlChars(outstr);
+          writeString(outstr);
         });
         writeString(']]></system-out>\n');
       }
@@ -176,7 +178,7 @@ function Jenkins(runner, options) {
       log();
       log('  Suite duration: '+(currentSuite.duration/1000)+' s, Tests: '+currentSuite.tests.length);
       try {
-      genSuiteReport();
+        genSuiteReport();
       } catch (err) { log(err) }
       currentSuite = null;
     }
@@ -191,19 +193,19 @@ function Jenkins(runner, options) {
   }
 
   function htmlEscape(str) {
-      return String(str)
-              .replace(/&/g, '&amp;')
-              .replace(/"/g, '&quot;')
-              .replace(/'/g, '&#39;')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;');
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
   }
 
   function unifiedDiff(err) {
     function escapeInvisibles(line) {
       return line.replace(/\t/g, '<tab>')
-                 .replace(/\r/g, '<CR>')
-                 .replace(/\n/g, '<LF>\n');
+          .replace(/\r/g, '<CR>')
+          .replace(/\n/g, '<LF>\n');
     }
     function cleanUp(line) {
       if (line.match(/\@\@/)) return null;
@@ -270,7 +272,7 @@ function Jenkins(runner, options) {
     if (reportPath) {
       if (fs.existsSync(reportPath)) {
         var isDirectory = fs.statSync(reportPath).isDirectory();
-        if (isDirectory) reportPath = path.join(reportPath, new Date().getTime() + ".xml"); 
+        if (isDirectory) reportPath = path.join(reportPath, new Date().getTime() + ".xml");
       } else {
         mkdirp.sync(path.dirname(reportPath));
       }
@@ -296,6 +298,7 @@ function Jenkins(runner, options) {
   runner.on('test', function (test) {
     test.logEntries = [];
     console.log = function () {
+      log.apply(this, arguments);
       test.logEntries.push(Array.prototype.slice.call(arguments));
     };
   });
@@ -307,24 +310,24 @@ function Jenkins(runner, options) {
 
   runner.on('pending', function(test) {
     var fmt = indent()
-      + color('checkmark', '  -')
-      + color('pending', ' %s');
+        + color('checkmark', '  -')
+        + color('pending', ' %s');
     log(fmt, test.title);
   });
 
   runner.on('pass', function(test) {
     currentSuite.passes++;
     var fmt = indent()
-      + color('checkmark', '  '+Base.symbols.dot)
-      + color('pass', ' %s: ')
-      + color(test.speed, '%dms');
-   log(fmt, test.title, test.duration);
+        + color('checkmark', '  '+Base.symbols.dot)
+        + color('pass', ' %s: ')
+        + color(test.speed, '%dms');
+    log(fmt, test.title, test.duration);
   });
 
   runner.on('fail', function(test, err) {
     var n = ++currentSuite.failures;
     var fmt = indent()
-      + color('fail', '  %d) %s');
+        + color('fail', '  %d) %s');
     log(fmt, n, test.title);
   });
 }

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -8,7 +8,8 @@ var Base = require('mocha').reporters.Base
   , fs = require('fs')
   , path = require('path')
   , diff= require('diff')
-  , mkdirp = require('mkdirp');
+  , mkdirp = require('mkdirp')
+  , util = require('util');
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -19,6 +20,11 @@ var Date = global.Date
   , setInterval = global.setInterval
   , clearTimeout = global.clearTimeout
   , clearInterval = global.clearInterval;
+
+/**
+ * Save original console.log.
+ */
+var log = console.log.bind(console);
 
 /**
  * Expose `Jenkins`.
@@ -43,6 +49,7 @@ function Jenkins(runner, options) {
   options.junit_report_stack = process.env.JUNIT_REPORT_STACK || options.junit_report_stack;
   options.junit_report_path = process.env.JUNIT_REPORT_PATH || options.junit_report_path;
   options.junit_report_name = process.env.JUNIT_REPORT_NAME || options.junit_report_name || 'Mocha Tests';
+  options.junit_report_packages = process.env.JUNIT_REPORT_PACKAGES || options.junit_report_packages;
   options.jenkins_reporter_enable_sonar = process.env.JENKINS_REPORTER_ENABLE_SONAR || options.jenkins_reporter_enable_sonar;
   options.jenkins_reporter_test_dir =  process.env.JENKINS_REPORTER_TEST_DIR || options.jenkins_reporter_test_dir  || 'test';
 
@@ -64,6 +71,22 @@ function Jenkins(runner, options) {
       return;
     }
 
+    if (options.screenshots) {
+      var imagestring = options.imagestring || htmlEscape(currentSuite.suite.fullTitle());
+      var imagetype = options.imagetype || 'png';
+      if (options.screenshots == 'loop') {
+        var screenshotIndex = 0;
+        var screenshots = [];
+        var screenshot = '';
+        var files = fs.readdirSync(options.junit_report_path).sort();
+        for(var i in files) {
+          if (files[i].indexOf(imagestring)>-1){
+            screenshots.push(files[i]);
+          }
+        }
+      }
+    }
+
     writeString('<testsuite');
     writeString(' name="'+htmlEscape(currentSuite.suite.fullTitle())+'"');
     writeString(' tests="'+testCount+'"');
@@ -73,70 +96,56 @@ function Jenkins(runner, options) {
     writeString(' time="'+(currentSuite.duration/1000)+'"');
     writeString('>\n');
 
-    if (currentSuite.tests.length === 0 && currentSuite.failures > 0) {
-      writeString('<testcase');
-      writeString(' classname="'+htmlEscape(currentSuite.suite.fullTitle())+'"');
-      writeString(' name="'+htmlEscape(currentSuite.suite.fullTitle())+' before"');
-      writeString('>\n');
-      writeString('<failure message="Failed during before hook"/>');
-      writeString('</testcase>\n');
-    } else {
+    var tests = currentSuite.tests;
 
-      //grabbing screenshots for 'loop' based approach
-      if (options.screenshots) {
-        var imageType = options.imagetype || 'png';
-        if (options.screenshots == 'loop') {
-          var screenshotIndex = 0;
-          var screenshots = [];
-          var screenshot = '';
-          var files = fs.readdirSync(options.junit_report_path).sort();
-          for(var i in files) {
-            if(path.extname(files[i]) === "." + imageType){
-              screenshots.push(files[i]);
-            }
+    if (tests.length === 0 && currentSuite.failures > 0) {
+      // Get the runnable that failed, which is a beforeAll or beforeEach
+      tests = [currentSuite.suite.ctx.runnable()];
+    }
+
+    tests.forEach(function(test) {
+      writeString('<testcase');
+      writeString(' classname="'+htmlEscape(getClassName(test, currentSuite.suite))+'"');
+      writeString(' name="'+htmlEscape(test.title)+'"');
+      writeString(' time="'+(test.duration/1000)+'">\n');
+      if (test.state == "failed") {
+
+        writeString('<failure message="');
+        if (test.err.message) writeString(htmlEscape(test.err.message));
+        writeString('">\n');
+        writeString(htmlEscape(unifiedDiff(test.err)));
+        writeString('\n</failure>\n');
+
+        //screenshot name is either pulled in sorted order from junit_report_path
+        //or set as suitename + classname + title, then written with Jenkins ATTACHMENT tag
+        if (options.screenshots) {
+          var screenshotDir = path.join(process.cwd(), options.junit_report_path);
+          if (options.screenshots == 'loop') {
+            screenshot = path.join(screenshotDir, screenshots[screenshotIndex]);
+            screenshotIndex++;
+          } else {
+            screenshot = path.join(screenshotDir, imagestring +
+                getClassName(test, currentSuite.suite) + test.title + "." + imagetype);
           }
+          writeString('<system-out>\n');
+          writeString('[[ATTACHMENT|' + screenshot + ']]');
+          writeString('\n</system-out>\n');
         }
+
+      } else if(test.state === undefined) {
+        writeString('<skipped/>\n');
       }
 
-      currentSuite.tests.forEach(function(test) {
-        writeString('<testcase');
-        writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
-        writeString(' name="'+htmlEscape(test.title)+'"');
-        writeString(' time="'+(test.duration/1000)+'"');
-        if (test.state == "failed") {
-          writeString('>\n');
-          writeString('<failure message="');
-          if (test.err.message) writeString(htmlEscape(test.err.message));
-          writeString('">\n');
-          writeString(htmlEscape(unifiedDiff(test.err)));
-          writeString('\n</failure>\n');
+      if (test.logEntries && test.logEntries.length) {
+        writeString('<system-out><![CDATA[');
+        test.logEntries.forEach(function (entry) {
+          writeString(util.format.apply(util, entry) + '\n');
+        });
+        writeString(']]></system-out>\n');
+      }
 
-          //screenshot name is either pulled in sorted order from junit_report_path
-          //or set as classname + title, then written with Jenkins ATTACHMENT tag
-          if (options.screenshots) {
-            var screenshotDir = path.join(process.cwd(), options.junit_report_path);
-            if (options.screenshots == 'loop') {
-              screenshot = path.join(screenshotDir, screenshots[screenshotIndex]);
-              screenshotIndex++;
-            } else {
-              screenshot = path.join(screenshotDir,
-                  getClassName(test, currentSuite.suite) + test.title + "." + imageType);
-            }
-            writeString('<system-out>\n');
-            writeString('[[ATTACHMENT|' + screenshot + ']]');
-            writeString('\n</system-out>\n');
-          }
-
-          writeString('</testcase>\n');
-        } else if(test.state === undefined) {
-          writeString('>\n');
-          writeString('<skipped/>\n');
-          writeString('</testcase>\n');
-        } else {
-          writeString('/>\n');
-        }
-      });
-    }
+      writeString('</testcase>\n');
+    });
 
     writeString('</testsuite>\n');
   }
@@ -149,18 +158,18 @@ function Jenkins(runner, options) {
       failures: 0,
       passes: 0
     };
-    console.log();
-    console.log("  "+suite.fullTitle());
+    log();
+    log("  "+suite.fullTitle());
   }
 
   function endSuite() {
     if (currentSuite != null) {
       currentSuite.duration = new Date - currentSuite.start;
-      console.log();
-      console.log('  Suite duration: '+(currentSuite.duration/1000)+' s, Tests: '+currentSuite.tests.length);
+      log();
+      log('  Suite duration: '+(currentSuite.duration/1000)+' s, Tests: '+currentSuite.tests.length);
       try {
       genSuiteReport();
-      } catch (err) { console.log(err) }
+      } catch (err) { log(err) }
       currentSuite = null;
     }
   }
@@ -226,17 +235,25 @@ function Jenkins(runner, options) {
     return msg;
   }
 
+  function getRelativePath(test) {
+    var relativeTestDir = options.jenkins_reporter_test_dir,
+        absoluteTestDir = path.join(process.cwd(), relativeTestDir);
+    return path.relative(absoluteTestDir, test.file);
+  }
+
   function getClassName(test, suite) {
-    var title = suite.fullTitle();
     if (options.jenkins_reporter_enable_sonar) {
       // Inspired by https://github.com/pghalliday/mocha-sonar-reporter
-      var relativeTestDir = options.jenkins_reporter_test_dir,
-          absoluteTestDir = path.join(process.cwd(), relativeTestDir),
-          relativeFilePath = path.relative(absoluteTestDir, test.file),
+      var relativeFilePath = getRelativePath(test),
           fileExt = path.extname(relativeFilePath);
-      title = relativeFilePath.replace(new RegExp(fileExt+"$"), '');
+      return relativeFilePath.replace(new RegExp(fileExt+"$"), '');
     }
-    return htmlEscape(title);
+    if (options.junit_report_packages) {
+      var testPackage = getRelativePath(test).replace(/[^\/]*$/, ''),
+          delimiter = testPackage ? '.' : '';
+      return testPackage + delimiter + suite.fullTitle();
+    }
+    return suite.fullTitle();
   }
 
   runner.on('start', function() {
@@ -268,16 +285,23 @@ function Jenkins(runner, options) {
     startSuite(suite);
   });
 
+  runner.on('test', function (test) {
+    test.logEntries = [];
+    console.log = function () {
+      test.logEntries.push(Array.prototype.slice.call(arguments));
+    };
+  });
 
   runner.on('test end', function(test) {
     addTestToSuite(test);
+    console.log = log;
   });
 
   runner.on('pending', function(test) {
     var fmt = indent()
       + color('checkmark', '  -')
       + color('pending', ' %s');
-    console.log(fmt, test.title);
+    log(fmt, test.title);
   });
 
   runner.on('pass', function(test) {
@@ -286,14 +310,14 @@ function Jenkins(runner, options) {
       + color('checkmark', '  '+Base.symbols.dot)
       + color('pass', ' %s: ')
       + color(test.speed, '%dms');
-   console.log(fmt, test.title, test.duration);
+   log(fmt, test.title, test.duration);
   });
 
   runner.on('fail', function(test, err) {
     var n = ++currentSuite.failures;
     var fmt = indent()
       + color('fail', '  %d) %s');
-    console.log(fmt, n, test.title);
+    log(fmt, n, test.title);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-jenkins-reporter",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "jenkins reporter for mocha",
   "main": "index.js",
   "directories": "./lib",


### PR DESCRIPTION
Jenkins screenshot attachments can be written to the report to allow for a screenshot attachment in each test failure. Simply specify a `reporterOption` of `spec` or `loop`. This writes a `system-out` xml element to the JUnit report, leveraging the `Publish test attachments` feature of the `JUnit Attachments Plugin`.

`spec` will write the full path of the screenshot with a filename consisting of "classname+test.title+extension". `loop` pulls and sorts all screenshots of a particular extension from `JUNIT_REPORT_PATH` and writes them in order according to the names of the files pulled.

Screenshot extension defaults to ".png", but can also be passed in with the `imagetype` reporterOption