### PR TITLE
Only write test duration if it exists

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -116,7 +116,10 @@ function Jenkins(runner, options) {
       writeString('<testcase');
       writeString(' classname="'+htmlEscape(getClassName(test, currentSuite.suite))+'"');
       writeString(' name="'+htmlEscape(test.title)+'"');
-      writeString(' time="'+(test.duration/1000)+'">\n');
+      if (test.duration) {
+        writeString(' time="'+(test.duration/1000)+'"');
+      }
+      writeString('>\n');
       if (test.state == "failed") {
         writeString('<failure message="');
         if (test.err.message) writeString(htmlEscape(test.err.message));
@@ -273,7 +276,7 @@ function Jenkins(runner, options) {
     if (reportPath) {
       if (fs.existsSync(reportPath)) {
         var isDirectory = fs.statSync(reportPath).isDirectory();
-        if (isDirectory) reportPath = path.join(reportPath, new Date().getTime() + ".xml"); 
+        if (isDirectory) reportPath = path.join(reportPath, new Date().getTime() + ".xml");
       } else {
         mkdirp.sync(path.dirname(reportPath));
       }


### PR DESCRIPTION
They way Mocha is set up, assertion errors in async tests aren't caught by the test itself, but by the test runner.

``` js
describe('a thing', function() {
  it('should do a thing', function(done) {
    setTimeout(function() {
      expect(false).to.be.true
      done()
    }, 100)
  })
})
```

Yields:

```
1) a thing should do a thing:
  Uncaught AssertionError: expected false to be true
```

Because it's "uncaught", the test never saves its own duration. Because `test.duration` is undefined, the XML report ends up with `time="NaN"` whenever an async test fails, which really confuses Jenkins (it ends up saying the suite run time is 0).

This PR changes the report behavior to only write test time to the report if it exists.
