### PR TITLE
Add all tests to the currentSuite regardless of completion status. Fixes #46

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -308,7 +308,6 @@ function Jenkins(runner, options) {
   });
 
   runner.on('test end', function(test) {
-    addTestToSuite(test);
     console.log = log;
   });
 
@@ -317,6 +316,7 @@ function Jenkins(runner, options) {
       + color('checkmark', '  -')
       + color('pending', ' %s');
     log(fmt, test.title);
+    addTestToSuite(test);
   });
 
   runner.on('pass', function(test) {
@@ -325,7 +325,8 @@ function Jenkins(runner, options) {
       + color('checkmark', '  '+Base.symbols.dot)
       + color('pass', ' %s: ')
       + color(test.speed, '%dms');
-   log(fmt, test.title, test.duration);
+    log(fmt, test.title, test.duration);
+    addTestToSuite(test);
   });
 
   runner.on('fail', function(test, err) {
@@ -333,6 +334,7 @@ function Jenkins(runner, options) {
     var fmt = indent()
       + color('fail', '  %d) %s');
     log(fmt, n, test.title);
+    addTestToSuite(test);
   });
 }
 


### PR DESCRIPTION
Follow the xunit convention and log tests using the `pending`, `pass` and `fail` events to ensure all failures are logged as test cases. See https://github.com/mochajs/mocha/blob/49b5ff1508dd8c0a84e6b2c20e49c50f8b6a1578/lib/reporters/xunit.js#L52

Fixes #46 