### PR TITLE
Handle failures outside of tests

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -337,6 +337,29 @@ function Jenkins(runner, options) {
   });
 
   runner.on('fail', function(test, err) {
+    if (currentSuite == undefined) {
+      // Failure occurred outside of a test suite.
+      console.error(err);
+      startSuite({tests:["other"], fullTitle: () => { return "Non-test failures"; }});
+      var n = ++currentSuite.failures;
+      var fmt = indent()
+        + color('fail', '  %d) %s');
+      if (test == undefined) {
+        log(fmt, n, "unknown");
+        addTestToSuite({
+          title: "unknown",
+          file: process.cwd() + "/other.js",
+          state: 'failed',
+          err: err
+        });
+      } else {
+        log(fmt, n, test.title);
+        addTestToSuite(test);
+      }
+      endSuite();
+      return;
+    }
+
     var n = ++currentSuite.failures;
     var fmt = indent()
       + color('fail', '  %d) %s');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-jenkins-reporter",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "jenkins reporter for mocha",
   "main": "index.js",
   "directories": "./lib",


### PR DESCRIPTION
This allows the test reporter to gracefully handle errors that occur outside of tests (such as in the "before all" hook).  Prior to this change the test reporter would cause Mocha to crash and mask the actual error that was occurring.
