### PR TITLE
Fix a misstake in the last PR

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -115,7 +115,7 @@ function Jenkins(runner, options) {
       };
 
       if (test.duration) {
-        testCase.testcase[0]['_attr'].duration = test.duration/1000;
+        testCase.testcase[0]['_attr'].time = test.duration/1000;
       }
 
       if (test.state == "failed") {


### PR DESCRIPTION
The "time" attribute was accidentally renamed to "duration" which makes
jenkins junit publisher display the time as 0ms for all tests suites.
This restores the old name used before PR #53.
It's called time time as well in the format referenced in the earlier PR so it looks like a simple misstake.