### PR TITLE
Add report name to class name

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -259,6 +259,9 @@ function Jenkins(runner, options) {
           delimiter = testPackage ? '.' : '';
       return testPackage + delimiter + suite.fullTitle();
     }
+    if (options.junit_report_name) {
+      return options.junit_report_name + '.' + suite.fullTitle();
+    }
     return suite.fullTitle();
   }
 


### PR DESCRIPTION
When not using JUNIT_REPORT_PACKAGES, all the tests results are gathered under "(root)" in Jenkins.  This small change adds JUNIT_REPORT_NAME to the class name so results are gathered under that instead.