### PR TITLE
Allow error to be thrown on failing tests

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -335,10 +335,9 @@ function Jenkins(runner, options) {
     addTestToSuite(test);
   });
 
-  runner.on('fail', function(test/*, err*/) {
+  runner.on('fail', function(test, err) {
     if (currentSuite == undefined) {
       // Failure occurred outside of a test suite.
-      console.error(err);
       startSuite({
         tests: ["other"],
         fullTitle: function() { return "Non-test failures"; }


### PR DESCRIPTION
1) Uncommented the error for `runner.on('fail', function(test, err) { ... }` listener. This appears to be commented out to avoid unhandled errors on test failure. 
2) Removed the `console.log(err)` because the errors are not being handled (Eg. a Reference Error will not be caught if the `console.log(err)` is left in)