### PR TITLE
Uncomment fail handler err parameter

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -335,7 +335,7 @@ function Jenkins(runner, options) {
     addTestToSuite(test);
   });
 
-  runner.on('fail', function(test/*, err*/) {
+  runner.on('fail', function(test, err) {
     if (currentSuite == undefined) {
       // Failure occurred outside of a test suite.
       console.error(err);


### PR DESCRIPTION
The error is logged 3 lines later and causes `ReferenceError`.