### PR TITLE
Moving eslint to the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   ],
   "dependencies": {
     "diff": "1.0.7",
-    "eslint": "3.12.1",
     "mkdirp": "0.5.1",
     "mocha": ">=2.0.0",
     "xml": "^1.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^3.12.1"
   },
   "author": "Juho Vähä-Herttua",
   "license": "MIT",


### PR DESCRIPTION
Hi! Many thanks for maintaining this module.

A small detail but everything adds up: moving eslint to the devDependencies saves 22MB of download:

```
➜  mocha-jenkins-reporter git:(master) npm i -g mocha-jenkins-reporter
/usr/local/lib
└─┬ mocha-jenkins-reporter@0.3.6
  ├─┬ eslint@3.12.1
  │ ├─┬ babel-code-frame@6.22.0
  │ │ └── js-tokens@3.0.1
...
➜  mocha-jenkins-reporter git:(master) du -sh /usr/local/lib/node_modules/mocha-jenkins-reporter/node_modules
 23M	/usr/local/lib/node_modules/mocha-jenkins-reporter/node_modules
➜  mocha-jenkins-reporter git:(master) npm i -g github:hmalphettes/mocha-jenkins-reporter
/usr/local/lib
└─┬ mocha-jenkins-reporter@0.3.6  (git://github.com/hmalphettes/mocha-jenkins-reporter.git#4133aad33dd9ea0ed757997b87716986bda008e9)
  ├── mocha@3.2.0
  └── xml@1.0.1

➜  mocha-jenkins-reporter git:(master) du -sh /usr/local/lib/node_modules/mocha-jenkins-reporter/node_modules
1.8M	/usr/local/lib/node_modules/mocha-jenkins-reporter/node_modules
```

I hope this helps.