### PR TITLE
Be sure to always include a time attribute for test cases

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -105,7 +105,8 @@ function Jenkins(runner, options) {
         'testcase': [{
           _attr: {
             classname: getClassName(test, currentSuite.suite),
-            name: test.title
+            name: test.title,
+            time: 0.000
           }
         }]
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-jenkins-reporter",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "jenkins reporter for mocha",
   "main": "index.js",
   "directories": "./lib",


### PR DESCRIPTION
Fixes juhovh/mocha-jenkins-reporter#65

Sets a default time attribute of 0, which is then overwritten if the test has a duration value.
