### PR TITLE
Use stripAnsi to remove any ANSI escape codes inside failure tags

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -8,6 +8,7 @@ var Base = require('mocha').reporters.Base
   , path = require('path')
   , diff= require('diff')
   , mkdirp = require('mkdirp')
+  , stripAnsi = require('strip-ansi')
   , util = require('util')
   , xml = require('xml');
 
@@ -239,7 +240,7 @@ function Jenkins(runner, options) {
       msg += lines.map(cleanUp).filter(notBlank).join('\n');
     }
 
-    return msg;
+    return stripAnsi(msg);
   }
 
   function getRelativePath(test) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/juhovh/mocha-jenkins-reporter/issues"
   },
   "devDependencies": {
-    "eslint": "3.12.1"
+    "eslint": "3.12.1",
+    "strip-ansi": "^4.0.0"
   }
 }


### PR DESCRIPTION
Ensure ANSI escape codes are removed from outputted xml.

Should fix https://github.com/juhovh/mocha-jenkins-reporter/issues/34