### PR TITLE
Fix mocha version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ General Information
 
 First you need to add the library to your package.json, you can use the following setting to get the latest version:
 
-`"mocha-jenkins-reporter": "0.3.9"`
+`"mocha-jenkins-reporter": "0.3.10"`
 
 For the actual test run you can add the following to package.json:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-jenkins-reporter",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "jenkins reporter for mocha",
   "main": "index.js",
   "directories": "./lib",
@@ -20,7 +20,7 @@
   "dependencies": {
     "diff": "1.0.7",
     "mkdirp": "0.5.1",
-    "mocha": ">=2.0.0",
+    "mocha": "^3.0.0",
     "xml": "^1.0.1"
   },
   "author": "Juho Vähä-Herttua",


### PR DESCRIPTION
This package is not compatible with mocha 4. Currently, if a test fails, it just hangs without reporting results.

Issue: #70 