### PR TITLE
Better support skipped cypress.io test cases

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -146,7 +146,7 @@ function Jenkins(runner, options) {
 
           testCase.testcase.push({'system-out': ['[[ATTACHMENT|' + screenshot + ']]']})
         }
-      } else if(test.state === undefined) {
+      } else if(test.state == 'pending') {
         testCase.testcase.push({skipped: {}});
       }
 
@@ -340,6 +340,7 @@ function Jenkins(runner, options) {
       + color('checkmark', '  -')
       + color('pending', ' %s');
     log(fmt, test.title);
+    test.state = test.state || 'pending';
     addTestToSuite(test);
   });
 


### PR DESCRIPTION
Cypress.io basically reports the `state` of a skipped test as `'pending'`. This library expected until now that state is `undefined` for skipped tests. With my change the state can now be `undefined` or `'pending'`