### PR TITLE
[misc] fix the dependency relation with mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "dependencies": {
     "diff": "4.0.1",
     "mkdirp": "0.5.1",
-    "mocha": "^5.2.0",
     "xml": "^1.0.1"
+  },
+  "peerDependencies": {
+    "mocha": "^5.2.0"
   },
   "author": "Juho Vähä-Herttua",
   "license": "MIT",


### PR DESCRIPTION
For details on this topic see
  https://nodejs.org/en/blog/npm/peer-dependencies/

TL;DR: we do not need a copy of mocha in our node_modules, when the
 actual application already has mocha as a dependency

```
dependencies of some application
| - mocha@4
` - mocha-jenkins-reporter
    ` - mocha@5
```

Signed-off-by: Jakob Ackermann <das7pad@outlook.com>