### PR TITLE
Add additional check to cast objects to strings for createPatch

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -240,6 +240,14 @@ function Jenkins(runner, options) {
         expected = JSON.stringify(err.expected);
       }
 
+      if (!(typeof actual === 'string' || actual instanceof String)) {
+        actual = String(actual);
+      }
+
+      if (!(typeof expected === 'string' || expected instanceof String)) {
+        expected = String(expected);
+      }
+
       var diffstr = diff.createPatch('string', actual, expected);
       lines = diffstr.split('\n').splice(4);
       msg += lines.map(cleanUp).filter(notBlank).join('\n');


### PR DESCRIPTION
When using chai-spies, the actual object ended up being something
that JSON.stringify couldn't cast to string, and it caused an exception:


``` 
TypeError: Cannot read property 'split' of undefined
    at Diff.tokenize (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/node_modules/diff/src/diff/line.js:7:32)
    at Diff.diff (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/node_modules/diff/src/diff/base.js:27:39)
    at diffLines (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/node_modules/diff/src/diff/line.js:31:71)
    at structuredPatch (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/node_modules/diff/src/patch/create.js:11:16)
    at createTwoFilesPatch (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/node_modules/diff/src/patch/create.js:103:16)
    at Object.createPatch (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/node_modules/diff/src/patch/create.js:127:10)
    at unifiedDiff (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/lib/jenkins.js:243:26)
    at /home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/lib/jenkins.js:131:13
    at Array.forEach (<anonymous>)
    at genSuiteReport (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/lib/jenkins.js:112:11)
    at endSuite (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/lib/jenkins.js:190:7)
    at Runner.<anonymous> (/home/kimmo/code/myrepo/node_modules/mocha-jenkins-reporter/lib/jenkins.js:306:5)
    at Runner.emit (events.js:327:22)
    at /home/kimmo/code/myrepo/node_modules/mocha/lib/runner.js:1014:12
    at /home/kimmo/code/myrepo/node_modules/mocha/lib/runner.js:858:7
    at next (/home/kimmo/code/myrepo/node_modules/mocha/lib/runner.js:448:14)
    at Immediate._onImmediate (/home/kimmo/code/myrepo/node_modules/mocha/lib/runner.js:514:5)
    at processImmediate (internal/timers.js:456:21)

```