### PR TITLE
Fix crash when running with mocha --parallel

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -168,17 +168,18 @@ function Jenkins(runner, options) {
   }
 
   function startSuite(suite) {
-    if (suite.tests.length > 0) {
-      currentSuite = {
-        suite: suite,
-        tests: [],
-        start: new Date,
-        failures: 0,
-        passes: 0
-      };
-      log();
-      log("  "+suite.fullTitle());
-    }
+    if (suite.tests && suite.tests.length === 0)
+      return;
+
+    currentSuite = {
+      suite: suite,
+      tests: [],
+      start: new Date,
+      failures: 0,
+      passes: 0
+    };
+    log();
+    log("  "+suite.fullTitle());
   }
 
   function endSuite() {


### PR DESCRIPTION
I hope this is a reasonable change. It seems mocha 8.0 doesn't provide a list of tests in the `suite` event when running in parallel mode. However, it seems that mocha-jenkins-reporter doesn't desparately need this data, as it seems to still work for me with this change.

Before
![image](https://user-images.githubusercontent.com/68302/101957679-cc92cb80-3bf9-11eb-8dd7-bce0af1130c8.png)

After
![image](https://user-images.githubusercontent.com/68302/101957728-e8966d00-3bf9-11eb-9c33-2883428d9b4a.png)
