### PR TITLE
Add 'Mocha@11' as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "xml": "^1.0.1"
   },
   "peerDependencies": {
-    "mocha": "^5.2.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+    "mocha": "^5.2.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
+  },
+  "overrides": {
+    "cross-spawn": "^7.0.6"
   },
   "author": "Juho Vähä-Herttua",
   "license": "MIT",
@@ -31,6 +34,6 @@
     "url": "https://github.com/juhovh/mocha-jenkins-reporter/issues"
   },
   "devDependencies": {
-    "eslint": "4.18.2"
+    "eslint": "^8.57.1"
   }
 }


### PR DESCRIPTION
Also this updates 'eslint' to v8.57.1 and overrides 'cross-spawn' to ^7.0.6 in order to fix the known vulnerabilities:

```

ajv  <6.12.3
Severity: moderate
Prototype Pollution in Ajv - https://github.com/advisories/GHSA-v88g-cgmw-v5xw
fix available via `npm audit fix --force`
Will install eslint@9.16.0, which is a breaking change
node_modules/ajv
  ajv-keywords  2.1.1
  Depends on vulnerable versions of ajv
  node_modules/ajv-keywords
  eslint  2.5.0 - 2.5.2 || 4.2.0 - 5.0.0-rc.0
  Depends on vulnerable versions of ajv
  Depends on vulnerable versions of cross-spawn
  Depends on vulnerable versions of table
  node_modules/eslint
  table  3.7.10 - 4.0.2
  Depends on vulnerable versions of ajv
  node_modules/table

cross-spawn  <6.0.6
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix --force`
Will install eslint@9.16.0, which is a breaking change
node_modules/cross-spawn

5 vulnerabilities (3 moderate, 2 high)
```

Fixes: #107